### PR TITLE
refactor: Remove madmom and simplify to librosa-only chord recognition

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,11 @@
 # YouTube Chord Extractor & MIDI Generator (chordsAI)
 
-A web application that downloads audio from YouTube videos, analyzes the audio to recognize chord progressions, and generates a corresponding MIDI file.
+A web application that downloads audio from YouTube videos, analyzes the audio to recognize chord progressions using `librosa`, and generates a corresponding MIDI file.
 
 ## Features
 
 *   Downloads audio from YouTube URLs.
-*   Recognizes chord progressions from the audio.
-    *   Primarily uses `madmom` for chord recognition (if available).
-    *   Includes a fallback mechanism using `librosa` if `madmom` is not installed or fails.
+*   Recognizes chord progressions from the audio using `librosa`.
 *   Generates a downloadable MIDI file based on the recognized chords.
 *   Simple, single-page web interface for URL input and results display.
 
@@ -17,11 +15,10 @@ A web application that downloads audio from YouTube videos, analyzes the audio t
 *   **Backend:** Python, Flask.
 *   **Core Python Libraries:**
     *   `yt-dlp`: For downloading audio from YouTube.
-    *   `madmom`: For advanced chord recognition.
-    *   `librosa`: For audio processing and chord recognition fallback.
+    *   `librosa`: For audio processing and chord recognition.
     *   `pretty_midi`: For generating MIDI files.
     *   `Flask`: Web framework for the backend API.
-    *   `Cython`, `numpy`, `scipy`: Essential libraries for scientific computing and dependencies for the core audio libraries.
+    *   `numpy`, `scipy`: Essential libraries for scientific computing and dependencies for `librosa`.
 
 ## Prerequisites
 
@@ -33,10 +30,6 @@ Before you begin, ensure you have the following installed:
     *   Download FFmpeg from [ffmpeg.org](https://ffmpeg.org/download.html).
     *   Ensure the `ffmpeg` (and `ffprobe`) executable is in your system's PATH or accessible by `yt-dlp`.
 4.  **Git (Optional):** For cloning the repository. Otherwise, you can download the source code as a ZIP file.
-5.  **A C Compiler (for `madmom`):** If you intend for `madmom` to install successfully (it's optional, as the app has a fallback), you'll need a C compiler.
-    *   **Linux:** Typically `gcc` (e.g., `sudo apt-get install build-essential python3-dev`).
-    *   **macOS:** Xcode Command Line Tools (e.g., `xcode-select --install`).
-    *   **Windows:** Build Tools for Visual Studio (select "C++ build tools" during installation).
 
 ## Setup and Installation
 
@@ -57,15 +50,10 @@ Before you begin, ensure you have the following installed:
         *   On Windows: `venv\Scripts\activate`
         *   On macOS/Linux: `source venv/bin/activate`
         (Your terminal prompt should now show `(venv)`.)
-    *   **Install Cython and NumPy:** These are critical build dependencies for `madmom` and should be installed before other packages.
-        ```bash
-        pip install Cython numpy
-        ```
-    *   **Install all other dependencies:**
+    *   **Install Python dependencies:**
         ```bash
         pip install -r requirements.txt
         ```
-    *   **Note on `madmom` Installation:** `madmom` provides high-quality chord recognition but can be challenging to install due to its C extensions. If it fails to install (even with Cython and NumPy pre-installed and a C compiler available), the application will automatically fall back to using `librosa` for chord recognition. The core functionality will still work.
     *   **FFmpeg Reminder:** Double-check that FFmpeg is installed and accessible in your system's PATH. `yt-dlp` will not be able to process audio effectively without it.
 
 3.  **Frontend Setup:**
@@ -80,22 +68,21 @@ Before you begin, ensure you have the following installed:
         ```bash
         python app.py
         ```
-    *   The backend server will start, typically on `http://localhost:5000`. You should see log messages in your terminal, including the availability status of `madmom`, `librosa`, and `pretty_midi`.
+    *   The backend server will start, typically on `http://localhost:5000`. You should see log messages in your terminal, including the availability status of `librosa` and `pretty_midi`.
 
 2.  **Launch the Frontend:**
     *   Open the `frontend/index.html` file directly in your web browser (e.g., by double-clicking it or using "File > Open" in your browser).
 
 ## Deployment to Railway (or similar platforms)
 
-Deploying this application to platforms like Railway requires careful attention to the build process, especially for the `madmom` library.
+Deploying this application to platforms like Railway involves specifying how the platform should build and run the application.
 
-**The `madmom` Installation Challenge:**
-The `madmom` library needs `Cython` and `numpy` to be installed *before* `madmom` itself is installed. Standard Python build processes on platforms often just run `pip install -r requirements.txt`, which might not install these dependencies in the correct order for `madmom`'s setup script to find them, leading to build failures.
+**Using `build.sh` (Optional Custom Build Control):**
+This repository includes a `build.sh` script. This script primarily upgrades `pip`, `setuptools`, and `wheel`, and then installs dependencies from `requirements.txt` using `pip install -r requirements.txt --no-cache-dir`. The `--no-cache-dir` flag ensures fresh package downloads, which can be beneficial in CI/CD environments.
 
-**Solution: `build.sh` Script:**
-To address this, this repository includes a `build.sh` script. This script ensures that `Cython` and `numpy` are installed first, followed by the rest of the dependencies from `requirements.txt`.
+While not strictly necessary for this simplified project (as `pip install -r requirements.txt` is often a default build command on many platforms), you can use `build.sh` for more explicit control over the build process if needed.
 
-**Using `build.sh` on Railway:**
+**To use `build.sh` on Railway:**
 
 1.  In your Railway project settings, navigate to the **Settings** tab, then find the **Build** section.
 2.  Locate the **Build Command** field.
@@ -103,16 +90,12 @@ To address this, this repository includes a `build.sh` script. This script ensur
     ```bash
     bash build.sh
     ```
-    (Using `bash build.sh` is generally safer to ensure it's executed with bash. If your `build.sh` has execute permissions, `build.sh` might also work, but `bash build.sh` is more explicit.)
-4.  Ensure your **Root Directory** setting in Railway (if applicable) correctly points to the root of your repository where `build.sh` and `requirements.txt` are located.
-5.  The `build.sh` script includes several important `pip` flags:
-    *   `--no-cache-dir`: This is beneficial in CI/CD environments to ensure fresh package downloads and avoid issues with cached versions.
-    *   `--no-build-isolation` (used when installing from `requirements.txt`): This is an advanced troubleshooting step to help with packages like `madmom` that have complex build-time requirements, by allowing them to access already installed packages like `Cython` and `NumPy` more easily during their build process.
+4.  Ensure your **Root Directory** setting in Railway (if applicable) correctly points to the root of your repository.
 
 For more general information on build configurations on Railway, refer to their official documentation:
 (See Railway's documentation for more details: https://docs.railway.com/guides/builds#build-command )
 
-This setup should allow `madmom` (and consequently all other dependencies) to install correctly in Railway's build environment. If `madmom` still encounters issues, the application's built-in fallback to `librosa` will be used. Also, ensure that your chosen Railway plan or environment has access to a C compiler and FFmpeg for full functionality. Railway's Nixpacks often handle common C dependencies, but FFmpeg might need to be explicitly included in your Nixpacks configuration if not available by default.
+Ensure that your chosen Railway plan or environment has access to FFmpeg for full functionality. Railway's Nixpacks often handle common C dependencies, but FFmpeg might need to be explicitly included in your Nixpacks configuration if not available by default.
 
 ## How to Use
 
@@ -122,13 +105,12 @@ This setup should allow `madmom` (and consequently all other dependencies) to in
 4.  Wait for processing. A loading indicator will be shown. This may take some time depending on the video.
 5.  **Results will be displayed:**
     *   A status message indicating the outcome.
-    *   The list of recognized chords and the method used (e.g., "madmom" or "librosa").
+    *   The list of recognized chords (using `librosa`).
     *   A download link for the generated MIDI file (if successful).
 6.  If an error occurs, an error message will be shown.
 
 ## Troubleshooting
 
-*   **`madmom` fails to install:** The application is designed to fall back to `librosa`. Ensure `Cython` and `numpy` were installed *before* `pip install -r requirements.txt` (the `build.sh` script handles this for deployments, using `--no-build-isolation`). If `madmom` is critical for you locally, ensure you have the necessary C compiler and Python development headers for your OS.
 *   **Errors related to "ffmpeg" or "ffprobe":** This means `yt-dlp` cannot find FFmpeg. Verify your FFmpeg installation and that its directory is in your system's PATH. For deployments, ensure your platform (e.g., Railway via Nixpacks) provides FFmpeg.
 *   **Frontend shows "Error: Failed to fetch" or similar:**
     *   Ensure the Flask backend server (`python app.py`) is running.

--- a/build.sh
+++ b/build.sh
@@ -1,15 +1,12 @@
 #!/bin/bash
 set -e # Exit immediately if a command exits with a non-zero status.
 
-echo "Starting custom build process..."
+echo "Starting build process..."
 
 # Upgrade pip and install setuptools and wheel first for good measure
 pip install --upgrade pip setuptools wheel
 
-echo "Installing Cython and NumPy first..."
-pip install Cython numpy --no-cache-dir # --no-cache-dir can sometimes help with fresher installs
-
-echo "Installing other dependencies from requirements.txt..."
-pip install --no-build-isolation -r requirements.txt --no-cache-dir
+echo "Installing dependencies from requirements.txt..."
+pip install -r requirements.txt --no-cache-dir # Removed --no-build-isolation
 
 echo "Build process completed."

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,6 @@
 Flask
 yt-dlp
-Cython
 numpy
 scipy
-madmom
 librosa
 pretty_midi


### PR DESCRIPTION
This commit removes madmom as a dependency and as a chord recognition option due to persistent build issues in automated environments. The application now exclusively uses librosa for chord recognition.

Changes include:
- Removed `madmom` and `Cython` from `requirements.txt`.
- Simplified `build.sh` by removing madmom-specific pre-installation steps and the `--no-build-isolation` flag.
- Updated `README.md` to reflect librosa as the sole chord recognition engine and removed madmom-related setup and troubleshooting information.
- Cleaned up `app.py` by removing all madmom-related code, imports, and logic. Chord recognition now directly uses librosa.

This simplification aims to ensure reliable builds and deployments, particularly on platforms like Railway.