### PR TITLE
fix: Use PORT environment variable for Flask app

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,9 @@ Before you begin, ensure you have the following installed:
         python app.py
         ```
     *   The backend server will start, typically on `http://localhost:5000`. You should see log messages in your terminal, including the availability status of `librosa` and `pretty_midi`.
+    *   **Note on Port Configuration:**
+        When running `python app.py` locally, the application defaults to port 5000.
+        When deployed to platforms like Railway, the application will automatically use the port number specified by the `PORT` environment variable set by the platform.
 
 2.  **Launch the Frontend:**
     *   Open the `frontend/index.html` file directly in your web browser (e.g., by double-clicking it or using "File > Open" in your browser).

--- a/app.py
+++ b/app.py
@@ -208,4 +208,5 @@ def analyze():
             except Exception as e: app.logger.error(f"Error cleaning {downloaded_mp3_path}: {e}")
 
 if __name__ == '__main__':
-    app.run(debug=True, host='0.0.0.0', port=5000)
+    port = int(os.environ.get('PORT', 5000)) # Default to 5000 if PORT not set
+    app.run(debug=False, host='0.0.0.0', port=port) # Set debug=False for production-like environment


### PR DESCRIPTION
Modifies app.py to listen on the port specified by the PORT environment variable, defaulting to 5000 if not set. This is to ensure compatibility with deployment platforms like Railway that dynamically assign ports. Debug mode is also set to False.

Updates README.md with a note on port configuration for local development versus platform deployment.